### PR TITLE
Fix default chat type typo

### DIFF
--- a/server/utils/helpers/chat/responses.js
+++ b/server/utils/helpers/chat/responses.js
@@ -149,7 +149,7 @@ function convertToChatHistory(history = []) {
         chatId: id,
       },
       {
-        type: data?.type || "chart",
+        type: data?.type || "chat",
         role: "assistant",
         content: data.text,
         sources: data.sources || [],


### PR DESCRIPTION
## Summary
- fix typo in chat history helper causing default message type to be `"chart"` instead of `"chat"`

## Testing
- `node -e "require('./server/utils/helpers/chat/responses.js')"` *(fails: Cannot find module 'uuid')*
