### PR TITLE
Add command palette support

### DIFF
--- a/frontend/src/components/CommandPalette.jsx
+++ b/frontend/src/components/CommandPalette.jsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { safeJsonParse } from "@/utils/request";
+
+/**
+ * Basic command palette component that fetches available commands from a
+ * websocket connection and allows users to execute them.
+ *
+ * @param {{ socket: WebSocket|null }} props
+ */
+export default function CommandPalette({ socket = null }) {
+  const [commands, setCommands] = useState([]);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    const handleMessage = (event) => {
+      const data = safeJsonParse(event.data, null);
+      if (data?.type === "commandList" && Array.isArray(data.content)) {
+        setCommands(data.content);
+      }
+    };
+
+    socket.addEventListener("message", handleMessage);
+    socket.send(JSON.stringify({ type: "listCommands" }));
+
+    return () => {
+      socket.removeEventListener("message", handleMessage);
+    };
+  }, [socket]);
+
+  const runCommand = (command) => {
+    if (!socket) return;
+    socket.send(
+      JSON.stringify({ type: "executeCommand", command: command.name })
+    );
+  };
+
+  if (commands.length === 0) return null;
+
+  return (
+    <div className="command-palette flex flex-col gap-2">
+      {commands.map((cmd) => (
+        <button
+          key={cmd.name}
+          onClick={() => runCommand(cmd)}
+          className="text-left px-2 py-1 rounded bg-theme-action-menu-item-hover"
+        >
+          <span className="font-semibold">{cmd.name}</span>
+          {cmd.description && (
+            <span className="block text-xs text-theme-text-secondary">
+              {cmd.description}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/server/utils/agents/aibitat/plugins/command-palette.js
+++ b/server/utils/agents/aibitat/plugins/command-palette.js
@@ -1,0 +1,39 @@
+const commandPalette = {
+  name: "command-palette",
+  startupConfig: {
+    params: {},
+  },
+  plugin: function () {
+    return {
+      name: this.name,
+      setup(aibitat) {
+        aibitat.commandPalette = {
+          /**
+           * List all available functions registered on the agent instance.
+           * @returns {Array<{name: string, description: string}>}
+           */
+          listCommands: function () {
+            return Array.from(aibitat.functions.values()).map((fn) => ({
+              name: fn.name,
+              description: fn.description || "",
+            }));
+          },
+          /**
+           * Execute a function by name with optional arguments.
+           * @param {string} name - The name of the command to execute
+           * @param {Object} args - Arguments to pass to the command
+           * @returns {Promise<any>} - Result of the command execution
+           */
+          execute: async function (name, args = {}) {
+            const fn = aibitat.functions.get(name);
+            if (!fn) throw new Error(`Command ${name} not found`);
+            fn.caller = "command-palette";
+            return await fn.handler.call(fn, args);
+          },
+        };
+      },
+    };
+  },
+};
+
+module.exports = { commandPalette };

--- a/server/utils/agents/aibitat/plugins/index.js
+++ b/server/utils/agents/aibitat/plugins/index.js
@@ -7,6 +7,7 @@ const { chatHistory } = require("./chat-history.js");
 const { memory } = require("./memory.js");
 const { rechart } = require("./rechart.js");
 const { sqlAgent } = require("./sql-agent/index.js");
+const { commandPalette } = require("./command-palette.js");
 
 module.exports = {
   webScraping,
@@ -18,6 +19,7 @@ module.exports = {
   memory,
   rechart,
   sqlAgent,
+  commandPalette,
 
   // Plugin name aliases so they can be pulled by slug as well.
   [webScraping.name]: webScraping,
@@ -29,4 +31,5 @@ module.exports = {
   [memory.name]: memory,
   [rechart.name]: rechart,
   [sqlAgent.name]: sqlAgent,
+  [commandPalette.name]: commandPalette,
 };

--- a/server/utils/agents/index.js
+++ b/server/utils/agents/index.js
@@ -552,6 +552,12 @@ class AgentHandler {
     );
     this.aibitat.use(AgentPlugins.chatHistory.plugin());
 
+    // Attach command palette plugin for user accessible commands.
+    this.log(
+      `Attached ${AgentPlugins.commandPalette.name} plugin to Agent cluster`
+    );
+    this.aibitat.use(AgentPlugins.commandPalette.plugin());
+
     // Load required agents (Default + custom)
     await this.#loadAgents();
 


### PR DESCRIPTION
## Summary
- add command palette plugin for AIbitat
- expose plugin from plugin index and load into agent handler
- basic React component to display commands and send actions

## Testing
- `npm run lint` *(fails: package doesn't seem to be present in lockfile)*