### PR TITLE
Add stub Google A2A integration

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,27 @@
+# Implementation Plan: Integrate Google A2A Protocol
+
+This document outlines the steps required to provide basic support for the [Google Agent2Agent (A2A) protocol](https://github.com/google/A2A) in AnythingLLM. The goal is to expose a minimal A2A compatible endpoint and agent card so that external agents can discover and interact with the platform.
+
+## 1. Serve an Agent Card
+- Create a JSON document compliant with the A2A `AgentCard` specification.
+- Host the card at `/.well-known/agent.json`.
+- Include basic metadata describing AnythingLLM and the base service URL (`/a2a/api`).
+- Initially advertise only simple chat capability with no streaming or push notification support.
+
+## 2. JSON‑RPC Endpoint
+- Add an Express route at `/a2a/api` to handle JSON‑RPC requests.
+- Validate the incoming request structure (`jsonrpc`, `method`, `params`).
+- For now, implement a stub handler for `message/send` that returns a placeholder response.
+- Respond with JSON‑RPC errors for unsupported methods or invalid payloads.
+
+## 3. Future Enhancements
+- Implement task management (`tasks/get`, `tasks/cancel`, etc.) with persistent state.
+- Add SSE support for `message/stream` and `tasks/resubscribe` when streaming is enabled.
+- Support push notifications via `tasks/pushNotificationConfig/*`.
+- Expose additional skills in the agent card as new capabilities are added.
+
+## 4. Deployment Notes
+- `PUBLIC_BASE_URL` environment variable should reflect the externally reachable URL of the server so that the agent card contains the correct service endpoint.
+- Ensure TLS is enabled in production deployments as required by the A2A specification.
+
+This initial integration allows experimentation with A2A while leaving room for a more complete implementation in the future.

--- a/server/endpoints/a2a.js
+++ b/server/endpoints/a2a.js
@@ -1,0 +1,85 @@
+const { reqBody } = require("../utils/http");
+
+function a2aEndpoints(app) {
+  if (!app) return;
+
+  const agentCard = {
+    name: "AnythingLLM A2A Agent",
+    description: "AnythingLLM exposes features via Google's Agent2Agent protocol.",
+    url: `${process.env.PUBLIC_BASE_URL || ""}/a2a/api`,
+    version: "0.1.0",
+    capabilities: {
+      streaming: false,
+      pushNotifications: false,
+    },
+    defaultInputModes: ["application/json", "text/plain"],
+    defaultOutputModes: ["application/json"],
+    skills: [
+      {
+        id: "chat",
+        name: "Chat",
+        description: "Handle chat messages via AnythingLLM",
+        tags: ["chat"],
+      },
+    ],
+  };
+
+  app.get("/.well-known/agent.json", (_req, res) => {
+    res.json(agentCard);
+  });
+
+  app.post("/a2a/api", (req, res) => {
+    try {
+      const body = reqBody(req);
+      if (!body || body.jsonrpc !== "2.0" || typeof body.method !== "string") {
+        return res.status(400).json({
+          jsonrpc: "2.0",
+          id: body?.id ?? null,
+          error: { code: -32600, message: "Invalid Request" },
+        });
+      }
+
+      switch (body.method) {
+        case "message/send": {
+          const message = body.params?.message;
+          if (!message) {
+            return res.status(400).json({
+              jsonrpc: "2.0",
+              id: body.id,
+              error: { code: -32602, message: "Invalid params" },
+            });
+          }
+          return res.json({
+            jsonrpc: "2.0",
+            id: body.id,
+            result: {
+              role: "agent",
+              parts: [
+                { kind: "text", text: "A2A integration placeholder" },
+              ],
+              messageId: message.messageId || "",
+              contextId: message.contextId || null,
+              kind: "message",
+              metadata: {},
+            },
+          });
+        }
+        default:
+          return res.status(400).json({
+            jsonrpc: "2.0",
+            id: body.id,
+            error: { code: -32601, message: "Method not found" },
+          });
+      }
+    } catch (e) {
+      console.error("A2A endpoint error", e);
+      res.status(500).json({
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32603, message: "Internal server error" },
+      });
+    }
+  });
+}
+
+module.exports = { a2aEndpoints };

--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,7 @@ const { communityHubEndpoints } = require("./endpoints/communityHub");
 const { agentFlowEndpoints } = require("./endpoints/agentFlows");
 const { mcpServersEndpoints } = require("./endpoints/mcpServers");
 const { taskQueueEndpoint } = require("./endpoints/taskQueue");
+const { a2aEndpoints } = require("./endpoints/a2a");
 const app = express();
 const apiRouter = express.Router();
 const FILE_LIMIT = "3GB";
@@ -68,6 +69,7 @@ experimentalEndpoints(apiRouter);
   agentFlowEndpoints(apiRouter);
   mcpServersEndpoints(apiRouter);
   taskEndpoints(apiRouter);
+  a2aEndpoints(app);
 
 // Externally facing embedder endpoints
 embeddedEndpoints(apiRouter);


### PR DESCRIPTION
## Summary
- document an implementation plan for adding Google's A2A protocol
- add endpoints to serve `/.well-known/agent.json` and handle `/a2a/api`
- register the new A2A endpoints in the Express server

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*