### PR TITLE
Implement partial A2A task + streaming support

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,27 @@
+# Implementation Plan: Integrate Google A2A Protocol
+
+This document outlines the steps required to provide basic support for the [Google Agent2Agent (A2A) protocol](https://github.com/google/A2A) in AnythingLLM. The goal is to expose a minimal A2A compatible endpoint and agent card so that external agents can discover and interact with the platform.
+
+## 1. Serve an Agent Card
+- Create a JSON document compliant with the A2A `AgentCard` specification.
+- Host the card at `/.well-known/agent.json`.
+- Include basic metadata describing AnythingLLM and the base service URL (`/a2a/api`).
+- Initially advertise only simple chat capability with no streaming or push notification support.
+
+## 2. JSON‑RPC Endpoint
+- Add an Express route at `/a2a/api` to handle JSON‑RPC requests.
+- Validate the incoming request structure (`jsonrpc`, `method`, `params`).
+- For now, implement a stub handler for `message/send` that returns a placeholder response.
+- Respond with JSON‑RPC errors for unsupported methods or invalid payloads.
+
+## 3. Future Enhancements
+- Basic in-memory task management added via `tasks/get` and `tasks/cancel`. Persistent storage can be added later.
+- Added SSE support for `message/stream` (single event response) and error stubs for `tasks/resubscribe`.
+- Push notifications via `tasks/pushNotificationConfig/*` remain unimplemented.
+- Additional skills can be exposed in the agent card as capabilities expand.
+
+## 4. Deployment Notes
+- `PUBLIC_BASE_URL` environment variable should reflect the externally reachable URL of the server so that the agent card contains the correct service endpoint.
+- Ensure TLS is enabled in production deployments as required by the A2A specification.
+
+This initial integration allows experimentation with A2A while leaving room for a more complete implementation in the future.

--- a/server/endpoints/a2a.js
+++ b/server/endpoints/a2a.js
@@ -1,0 +1,114 @@
+const { reqBody } = require("../utils/http");
+const { getAgentCard } = require("../utils/a2aAgentCard");
+const { createTask, getTask, cancelTask } = require("../utils/a2aTasks");
+
+function a2aEndpoints(app) {
+  if (!app) return;
+
+  const agentCard = getAgentCard();
+
+  app.get("/.well-known/agent.json", (_req, res) => {
+    res.json(agentCard);
+  });
+
+  app.post("/a2a/api", (req, res) => {
+    try {
+      const body = reqBody(req);
+      if (!body || body.jsonrpc !== "2.0" || typeof body.method !== "string") {
+        return res.status(400).json({
+          jsonrpc: "2.0",
+          id: body?.id ?? null,
+          error: { code: -32600, message: "Invalid Request" },
+        });
+      }
+
+      switch (body.method) {
+        case "message/send": {
+          const message = body.params?.message;
+          if (!message) {
+            return res.status(400).json({
+              jsonrpc: "2.0",
+              id: body.id,
+              error: { code: -32602, message: "Invalid params" },
+            });
+          }
+          const task = createTask(message);
+          return res.json({ jsonrpc: "2.0", id: body.id, result: task });
+        }
+        case "message/stream": {
+          const message = body.params?.message;
+          if (!message) {
+            return res.status(400).json({
+              jsonrpc: "2.0",
+              id: body.id,
+              error: { code: -32602, message: "Invalid params" },
+            });
+          }
+          const task = createTask(message);
+          res.setHeader("Cache-Control", "no-cache");
+          res.setHeader("Content-Type", "text/event-stream");
+          res.setHeader("Connection", "keep-alive");
+          res.flushHeaders();
+          const event = { jsonrpc: "2.0", id: body.id, result: task };
+          res.write(`data: ${JSON.stringify(event)}\n\n`);
+          res.end();
+          return;
+        }
+        case "tasks/get": {
+          const id = body.params?.id;
+          const task = id ? getTask(id) : null;
+          if (!task) {
+            return res.status(400).json({
+              jsonrpc: "2.0",
+              id: body.id,
+              error: { code: -32001, message: "Task not found" },
+            });
+          }
+          return res.json({ jsonrpc: "2.0", id: body.id, result: task });
+        }
+        case "tasks/cancel": {
+          const id = body.params?.id;
+          const task = id ? cancelTask(id) : null;
+          if (!task) {
+            return res.status(400).json({
+              jsonrpc: "2.0",
+              id: body.id,
+              error: { code: -32001, message: "Task not found" },
+            });
+          }
+          return res.json({ jsonrpc: "2.0", id: body.id, result: task });
+        }
+        case "tasks/resubscribe": {
+          return res.status(400).json({
+            jsonrpc: "2.0",
+            id: body.id,
+            error: { code: -32004, message: "Streaming not yet supported" },
+          });
+        }
+        case "tasks/pushNotificationConfig/set":
+        case "tasks/pushNotificationConfig/get": {
+          return res.status(400).json({
+            jsonrpc: "2.0",
+            id: body.id,
+            error: { code: -32004, message: "Push notifications not supported" },
+          });
+        }
+        default:
+          return res.status(400).json({
+            jsonrpc: "2.0",
+            id: body.id,
+            error: { code: -32601, message: "Method not found" },
+          });
+      }
+    } catch (e) {
+      console.error("A2A endpoint error", e);
+      res.status(500).json({
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32603, message: "Internal server error" },
+      });
+    }
+  });
+}
+
+module.exports = { a2aEndpoints };

--- a/server/index.js
+++ b/server/index.js
@@ -29,6 +29,7 @@ const { communityHubEndpoints } = require("./endpoints/communityHub");
 const { agentFlowEndpoints } = require("./endpoints/agentFlows");
 const { mcpServersEndpoints } = require("./endpoints/mcpServers");
 const { taskQueueEndpoint } = require("./endpoints/taskQueue");
+const { a2aEndpoints } = require("./endpoints/a2a");
 const app = express();
 const apiRouter = express.Router();
 const FILE_LIMIT = "3GB";
@@ -68,6 +69,7 @@ experimentalEndpoints(apiRouter);
   agentFlowEndpoints(apiRouter);
   mcpServersEndpoints(apiRouter);
   taskEndpoints(apiRouter);
+  a2aEndpoints(app);
 
 // Externally facing embedder endpoints
 embeddedEndpoints(apiRouter);

--- a/server/utils/a2aAgentCard.js
+++ b/server/utils/a2aAgentCard.js
@@ -1,0 +1,24 @@
+function getAgentCard() {
+  return {
+    name: "AnythingLLM A2A Agent",
+    description: "AnythingLLM exposes features via Google's Agent2Agent protocol.",
+    url: `${process.env.PUBLIC_BASE_URL || ""}/a2a/api`,
+    version: "0.1.0",
+    capabilities: {
+      streaming: true,
+      pushNotifications: false,
+    },
+    defaultInputModes: ["application/json", "text/plain"],
+    defaultOutputModes: ["application/json"],
+    skills: [
+      {
+        id: "chat",
+        name: "Chat",
+        description: "Handle chat messages via AnythingLLM",
+        tags: ["chat"],
+      },
+    ],
+  };
+}
+
+module.exports = { getAgentCard };

--- a/server/utils/a2aTasks.js
+++ b/server/utils/a2aTasks.js
@@ -1,0 +1,33 @@
+const { v4: uuidv4 } = require('uuid');
+
+const tasks = new Map();
+
+function createTask(message) {
+  const id = uuidv4();
+  const contextId = message.contextId || uuidv4();
+  const task = {
+    id,
+    contextId,
+    status: { state: 'completed' },
+    artifacts: [],
+    history: [message],
+    metadata: {},
+  };
+  tasks.set(id, task);
+  return task;
+}
+
+function getTask(id) {
+  return tasks.get(id) || null;
+}
+
+function cancelTask(id) {
+  const task = tasks.get(id);
+  if (!task) return null;
+  if (!['completed','canceled','failed','rejected'].includes(task.status.state)) {
+    task.status.state = 'canceled';
+  }
+  return task;
+}
+
+module.exports = { createTask, getTask, cancelTask };


### PR DESCRIPTION
## Summary
- add in-memory task management and SSE message streaming
- centralize agent card info in dedicated module
- expand JSON-RPC handler with tasks/get, tasks/cancel, message/stream stubs
- update implementation plan to reflect new progress

## Testing
- `yarn lint` *(fails: package not present in lockfile)*