### PR TITLE
Add A2A webhook support

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -6,7 +6,7 @@ This document outlines the steps required to provide basic support for the [Goog
 - Create a JSON document compliant with the A2A `AgentCard` specification.
 - Host the card at `/.well-known/agent.json`.
 - Include basic metadata describing AnythingLLM and the base service URL (`/a2a/api`).
-- Initially advertise only simple chat capability with no streaming or push notification support.
+- Initially advertise simple chat capability with optional streaming and webhook push notification support.
 
 ## 2. JSON‑RPC Endpoint
 - Add an Express route at `/a2a/api` to handle JSON‑RPC requests.
@@ -17,7 +17,7 @@ This document outlines the steps required to provide basic support for the [Goog
 ## 3. Future Enhancements
 - Basic in-memory task management added via `tasks/get` and `tasks/cancel`. Persistent storage can be added later.
 - Added SSE support for `message/stream` (single event response) and error stubs for `tasks/resubscribe`.
-- Push notifications via `tasks/pushNotificationConfig/*` remain unimplemented.
+- Basic webhook support added via `tasks/pushNotificationConfig/*` to allow POST notifications when tasks are created.
 - Additional skills can be exposed in the agent card as capabilities expand.
 
 ## 4. Deployment Notes

--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ the orchestrator will appear in the `/task-monitor` stream.
 
 [Learn about vector caching](./server/storage/vector-cache/VECTOR_CACHE.md)
 
+### Google A2A Agent Protocol
+
+AnythingLLM exposes a minimal [A2A](https://github.com/google/A2A) compatible API at `/a2a/api`. The agent card is served at `/.well-known/agent.json`.
+Tasks are tracked in memory and can be retrieved with `tasks/get` or cancelled with `tasks/cancel`. Chat messages can stream results via `message/stream`.
+Configure a webhook for push notifications using `tasks/pushNotificationConfig/set` and fetch the current setting via `tasks/pushNotificationConfig/get`.
+
 ## External Apps & Integrations
 
 _These are apps that are not maintained by Mintplex Labs, but are compatible with AnythingLLM. A listing here is not an endorsement._

--- a/server/endpoints/a2a.js
+++ b/server/endpoints/a2a.js
@@ -1,6 +1,10 @@
 const { reqBody } = require("../utils/http");
 const { getAgentCard } = require("../utils/a2aAgentCard");
 const { createTask, getTask, cancelTask } = require("../utils/a2aTasks");
+const {
+  setPushNotificationConfig: setPushConfig,
+  getPushNotificationConfig: getPushConfig,
+} = require("../utils/a2aPushNotifications");
 
 function a2aEndpoints(app) {
   if (!app) return;
@@ -85,13 +89,28 @@ function a2aEndpoints(app) {
             error: { code: -32004, message: "Streaming not yet supported" },
           });
         }
-        case "tasks/pushNotificationConfig/set":
+        case "tasks/pushNotificationConfig/set": {
+          const url = body.params?.url;
+          const config = setPushConfig({ url });
+          if (!config) {
+            return res.status(400).json({
+              jsonrpc: "2.0",
+              id: body.id,
+              error: { code: -32602, message: "Invalid params" },
+            });
+          }
+          return res.json({ jsonrpc: "2.0", id: body.id, result: config });
+        }
         case "tasks/pushNotificationConfig/get": {
-          return res.status(400).json({
-            jsonrpc: "2.0",
-            id: body.id,
-            error: { code: -32004, message: "Push notifications not supported" },
-          });
+          const config = getPushConfig();
+          if (!config) {
+            return res.status(400).json({
+              jsonrpc: "2.0",
+              id: body.id,
+              error: { code: -32004, message: "Push notifications not configured" },
+            });
+          }
+          return res.json({ jsonrpc: "2.0", id: body.id, result: config });
         }
         default:
           return res.status(400).json({

--- a/server/utils/a2aAgentCard.js
+++ b/server/utils/a2aAgentCard.js
@@ -6,7 +6,7 @@ function getAgentCard() {
     version: "0.1.0",
     capabilities: {
       streaming: true,
-      pushNotifications: false,
+      pushNotifications: true,
     },
     defaultInputModes: ["application/json", "text/plain"],
     defaultOutputModes: ["application/json"],

--- a/server/utils/a2aPushNotifications.js
+++ b/server/utils/a2aPushNotifications.js
@@ -1,0 +1,26 @@
+let pushNotificationConfig = null;
+
+function setPushNotificationConfig(config) {
+  if (!config || typeof config.url !== 'string') return null;
+  pushNotificationConfig = { url: config.url };
+  return pushNotificationConfig;
+}
+
+function getPushNotificationConfig() {
+  return pushNotificationConfig;
+}
+
+async function sendPushNotification(task) {
+  if (!pushNotificationConfig?.url) return;
+  try {
+    await fetch(pushNotificationConfig.url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(task),
+    });
+  } catch (e) {
+    console.error('Failed to send push notification', e);
+  }
+}
+
+module.exports = { setPushNotificationConfig, getPushNotificationConfig, sendPushNotification };

--- a/server/utils/a2aTasks.js
+++ b/server/utils/a2aTasks.js
@@ -1,4 +1,5 @@
 const { v4: uuidv4 } = require('uuid');
+const { sendPushNotification } = require('./a2aPushNotifications');
 
 const tasks = new Map();
 
@@ -14,6 +15,8 @@ function createTask(message) {
     metadata: {},
   };
   tasks.set(id, task);
+  // Notify external systems if configured
+  sendPushNotification(task);
   return task;
 }
 


### PR DESCRIPTION
## Summary
- implement push notification config endpoints
- send webhook notification when tasks are created
- advertise push notification capability in AgentCard
- document new A2A API usage
- note webhook support in implementation plan

## Testing
- `yarn lint` *(fails: package doesn't seem to be present in lockfile)*