### PR TITLE
Add HITL task support

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -23,6 +23,7 @@ These features are planned next to make the A2A implementation spec‑complete:
 - Persist tasks in a database or external store instead of memory.
 - Extend the agent card with additional skills and metadata as new features are added.
 - Expand automated tests and lint checks once CI installs dependencies.
+- Support pausing queued tasks for human review via new orchestrator endpoints.
 
 ## Deployment Notes
 - Set `PUBLIC_BASE_URL` to the externally reachable server URL so the agent card advertises the correct endpoint.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ project scoped files named `project-<slug>.modes.json` can be created to extend
 or override the global modes for a specific workspace. Tasks delegated through
 the orchestrator will appear in the `/task-monitor` stream.
 
+Modes may specify `"requiresHuman": true` to pause processing until a person
+approves the task. Use `POST /api/tasks/:id/resume` to continue or
+`POST /api/tasks/:id/await-human` to manually pause any queued task.
+
 [Learn about documents](./server/storage/documents/DOCUMENTS.md)
 
 [Learn about vector caching](./server/storage/vector-cache/VECTOR_CACHE.md)
@@ -194,6 +198,7 @@ Configure a webhook for push notifications using `tasks/pushNotificationConfig/s
 Tasks may request more input via an `input-required` state before completing. You can
 reconnect to the event stream with `tasks/resubscribe` and receive updates on every
 status transition. File uploads are echoed back as artifacts when processed.
+Tasks may also be paused for manual review with `POST /api/tasks/:id/await-human` and resumed via `POST /api/tasks/:id/resume`.
 
 ## External Apps & Integrations
 

--- a/server/endpoints/taskQueue.js
+++ b/server/endpoints/taskQueue.js
@@ -4,6 +4,18 @@ const { stateMgr } = require('../utils/stateMgr');
 function taskQueueEndpoint(app) {
   if (!app || !app.ws) return;
 
+  app.post('/tasks/:id/await-human', (req, res) => {
+    const { id } = req.params;
+    taskQueue.awaitHuman(id);
+    res.json({ id, status: 'awaiting-human' });
+  });
+
+  app.post('/tasks/:id/resume', (req, res) => {
+    const { id } = req.params;
+    taskQueue.resume(id);
+    res.json({ id, status: 'pending' });
+  });
+
   app.ws('/task-monitor', function (socket) {
     const sendAll = () => {
       socket.send(

--- a/server/utils/a2aTasks.js
+++ b/server/utils/a2aTasks.js
@@ -47,4 +47,11 @@ function cancelTask(id) {
   return task;
 }
 
-module.exports = { createTask, getTask, cancelTask, setStatus, tasks };
+function requestHumanInput(id, msgParts = []) {
+  const task = tasks.get(id);
+  if (!task) return null;
+  setStatus(task, 'input-required', msgParts);
+  return task;
+}
+
+module.exports = { createTask, getTask, cancelTask, requestHumanInput, setStatus, tasks };

--- a/server/utils/orchestrator/index.js
+++ b/server/utils/orchestrator/index.js
@@ -66,6 +66,9 @@ class AgentOrchestrator {
     const mode = this.mode(slug);
     if (!mode) throw new Error(`Unknown mode slug: ${slug}`);
     const id = taskQueue.add({ ...payload, mode: slug }, { ...options, group: slug });
+    if (mode.requiresHuman) {
+      taskQueue.awaitHuman(id);
+    }
     return id;
   }
 }

--- a/server/utils/taskQueue/index.js
+++ b/server/utils/taskQueue/index.js
@@ -83,6 +83,23 @@ class TaskQueue {
     }
   }
 
+  awaitHuman(taskId) {
+    const task = this.tasks.find(t => t.id === taskId);
+    if (task) {
+      task.status = 'awaiting-human';
+      task.locked = false;
+      stateMgr.set(task.id, 'awaiting-human');
+    }
+  }
+
+  resume(taskId) {
+    const task = this.tasks.find(t => t.id === taskId);
+    if (task && task.status === 'awaiting-human') {
+      task.status = 'pending';
+      stateMgr.set(task.id, 'pending');
+    }
+  }
+
   list() {
     return this.tasks.map(t => ({
       id: t.id,


### PR DESCRIPTION
## Summary
- document future plan for human task pausing
- document human review options in the README
- allow pausing/resuming queued tasks via new endpoints
- let Orchestrator pause modes requiring humans
- enable human prompts in A2A tasks
- add human-wait/resume status handling in task queue

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*